### PR TITLE
feat: Add help string and new command for online lessons

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,8 +1,12 @@
+import os
+
 import guidebook
 import knowledge
 
+
 HRYVNIA_TITLE = "Обмен гривен/Exchange hryvnia"
 LEGAL_TITLE = "Юридическая помощь/Legal help"
+TEACHERS_TITLE = "Онлайн уроки для детей/Online lessons for children"
 
 
 def get_from_knowledge(title):
@@ -17,6 +21,25 @@ def cities(book, name=None):
 def countries(book, name=None):
     return guidebook.countries(book, name)
 
+def help():
+    return ("Привет! Используйте одну из команд: "
+           + "/cities чтобы увидеть все чаты помощи по городам Германии"
+           + "/countries чтобы увидеть все чаты помощи по странам"
+           + "/hryvnia чтобы получить информацию про обмен гривен"
+           + "/legal чтобы получить юридическую помощь"
+           + "/evacuation общие чаты об эвакуации из Украины"
+           + "/evacuationCities чаты эвакуации по городам"
+           + "/childrenLessons онлайн уроки для детей из Украины"
+           + os.linesep()
+           + "Hi! Please use one of the following commands: "
+           + "/cities to display existing chats for cities in Germany"
+           + "/countries to display existing chats for the countries"
+           + "/hryvnia to display information about hryvnia exchange"
+           + "/legal to get information about legal help"
+           + "/evacuation to get information about evacuation from Ukraine"
+           + "/evacuationCities evacuation chats for cities"
+           + "/childrenLessons online lessons for children from Ukraine")
+
 
 def hryvnia():
     return get_from_knowledge(HRYVNIA_TITLE)
@@ -24,6 +47,10 @@ def hryvnia():
 
 def legal():
     return get_from_knowledge(LEGAL_TITLE)
+
+
+def teachers_for_peace(book):
+    return get_from_knowledge(TEACHERS_TITLE)
 
 
 def evacuation(book):

--- a/knowledge.json
+++ b/knowledge.json
@@ -22,11 +22,15 @@
     },
     {
       "title": "Обмен гривен/Exchange hryvnia",
-      "content": "На данный момент нигде в Германии нельзя обменять гривны.\nГоворят в Польше, Варшавe есть 1 обменник, который принимает гривны \nИли в Украине класть на карточку. Карточкой украинской тут можно расплачиваться и снимать деньги"
+      "content": "На данный момент нигде в Германии нельзя обменять гривны.\nГоворят, в Польше (Варшавe) есть 1 обменник, который принимает гривны. \nИли в Украине класть на карточку. Карточкой украинской можно расплачиваться и снимать деньги в Европе."
     },
     {
       "title": "Официальная информация/Official statements",
       "content": "https://www.berlin.de/ukraine/uk/pributtja/\n\nhttps://www.bmi.bund.de/SharedDocs/faqs/DE/themen/ministerium/ukrain-war-ukr/faq-list-ukrain-war.html \n\nhttps://berlin-hilft.com/2022/03/04/ukraine-infos-zu-registrierung-und-leistungsbeantragung-in-berlin/#U\n\nhttps://handbookgermany.de/de/ukraine-info/ua.html\n\nhttps://www.proasyl.de/wp-content/uploads/Ratsbeschluss_Russisch.pdf"
+    },
+    {
+        "title": "Онлайн уроки для детей/Online lessons for children",
+        "content": "https://t.me/+ltsKWvkl6CU1MTEy"
     },
     {
       "title": "Медицинская помощь/Medical help",

--- a/main.py
+++ b/main.py
@@ -81,7 +81,9 @@ def send_reminder(bot: Bot, chat_id: str):
 
 def help_command(bot: Bot, update: Update) -> None:
     """Send a message when the command /help is issued."""
-    send_reminder(bot, chat_id=update.message.chat_id)
+    help = commands.help()
+    bot.send_message(chat_id=update.message.chat_id, text=help)
+
 
 
 def delete_greetings(bot: Bot, update: Update) -> None:
@@ -190,6 +192,11 @@ def legal_command(bot: Bot, update: Update):
     bot.send_message(chat_id=update.message.chat_id, text=results)
 
 
+def children_lessons(bot: Bot, update: Update):
+    results = commands.teachers_for_peace()
+    bot.send_message(chat_id=update.message.chat_id, text=results)
+
+
 def evac_command(bot: Bot, update: Update):
     results = commands.evacuation(BOOK)
     bot.send_message(chat_id=update.message.chat_id, text=results)
@@ -221,6 +228,8 @@ def main() -> None:
 
     dispatcher.add_handler(CommandHandler("evacuation", evac_command))
     dispatcher.add_handler(CommandHandler("evacuationCities", evac_cities_command))
+
+    dispatcher.add_handler(CommandHandler("childrenLessons", children_lessons))
 
 
     # Messages


### PR DESCRIPTION
This PR:
- adds a string to the "/help" message which describes all available commands. This is not very convenient and has to be changed every time we add a new command. Thus, I would be in favour of replacing this with some general information, and having the list of commands in the [Botfather](https://core.telegram.org/bots#6-botfather) (they will be suggested and displayed really nicely that way).
- adds a new command to a chat for online lessons for kids from Ukraine

NB: this has not been tested yet.